### PR TITLE
Update GitHub actions and cleanup unused workflow

### DIFF
--- a/.github/actions/setup-pdm-env/action.yaml
+++ b/.github/actions/setup-pdm-env/action.yaml
@@ -11,7 +11,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ inputs.python-version }}
 

--- a/.github/actions/setup-pdm-env/action.yaml
+++ b/.github/actions/setup-pdm-env/action.yaml
@@ -16,7 +16,7 @@ runs:
         python-version: ${{ inputs.python-version }}
 
     - name: Install PDM
-      uses: pdm-project/setup-pdm@v3
+      uses: pdm-project/setup-pdm@v4
       with:
         python-version: 3.9
         cache: true

--- a/.github/actions/setup-pdm-env/action.yaml
+++ b/.github/actions/setup-pdm-env/action.yaml
@@ -1,11 +1,13 @@
+---
+
 name: "setup-pdm-env"
 description: "Composite action to setup the Python and PDM environment."
 
 inputs:
-   python-version:
-     required: false
-     description: "The python version to use"
-     default: "3.11"
+  python-version:
+    required: false
+    description: "The python version to use"
+    default: "3.11"
 
 runs:
   using: "composite"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - uses: actions/cache@v3
         with:
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up the environment
         uses: ./.github/actions/setup-pdm-env

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Check out
         uses: actions/checkout@v4
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/pre-commit
           key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
@@ -24,43 +24,6 @@ jobs:
 
       - name: Run checks
         run: make check
-
-#  tox:
-#    runs-on: ubuntu-latest
-#    strategy:
-#      matrix:
-#        python-version: ['3.9', '3.10', '3.11']
-#      fail-fast: false
-#    steps:
-#      - name: Check out
-#        uses: actions/checkout@v3
-#
-#      - name: Set up python
-#        uses: actions/setup-python@v4
-#        with:
-#          python-version: ${{ matrix.python-version }}
-#
-#      - name: Install PDM
-#        uses: pdm-project/setup-pdm@v3
-#        with:
-#          python-version: 3.9
-#          cache: true
-#
-#      - name: Install dependencies
-#        run: pdm install
-#        shell: bash
-#
-##      - name: Install tox
-##        run: |
-##          python -m pip install --upgrade pip
-##          python -m pip install tox tox-gh-actions
-##
-##      - name: Test with tox
-##        run: tox
-##
-##      - name: Upload coverage reports to Codecov with GitHub Action on Python 3.11
-##        uses: codecov/codecov-action@v3
-##        if: ${{ matrix.python-version == '3.11' }}
 
   check-docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,3 +1,5 @@
+---
+
 name: Main
 
 on:

--- a/.github/workflows/on-release-main.yaml
+++ b/.github/workflows/on-release-main.yaml
@@ -1,3 +1,5 @@
+---
+
 name: release-main
 
 on:

--- a/.github/workflows/on-release-main.yaml
+++ b/.github/workflows/on-release-main.yaml
@@ -16,9 +16,9 @@ jobs:
       # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: pdm-project/setup-pdm@v3
+      - uses: pdm-project/setup-pdm@v4
 
       - name: Publish package distributions to PyPI
         run: pdm publish
@@ -32,7 +32,7 @@ jobs:
       contents: write
     steps:
       - name: Check out
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up the environment
         uses: ./.github/actions/setup-pdm-env

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # minio-manager
 
-[![Release](https://img.shields.io/github/v/release/Alveel/minio-manager?include_prereleases)](https://img.shields.io/github/v/release/alveel/minio-manager)
+[![Release](https://img.shields.io/github/v/release/Alveel/minio-manager?include_prereleases)](https://img.shields.io/github/v/release/Alveel/minio-manager?include_prereleases)
 [![Build status](https://img.shields.io/github/actions/workflow/status/Alveel/minio-manager/main.yaml)](https://github.com/alveel/minio-manager/actions/workflows/main.yml?query=branch%3Amain)
 [![Commit activity](https://img.shields.io/github/commit-activity/m/alveel/minio-manager)](https://img.shields.io/github/commit-activity/m/alveel/minio-manager)
 [![License](https://img.shields.io/github/license/alveel/minio-manager)](https://img.shields.io/github/license/alveel/minio-manager)
@@ -23,6 +23,7 @@ delete any resources anywhere.
 
 - [Python](https://www.python.org/) (3.9 or newer)
 - [PDM](https://pdm-project.org/)
+- [MinIO Client](https://min.io/docs/minio/linux/reference/minio-mc.html)
 
 ## Getting started with your project
 
@@ -120,16 +121,7 @@ Entries are found by way of the title of the entry, the username is not consider
 
 ## To do features
 
-- Check if policies are already attached to a user before running the "attach" command.
-- Automatically generate keepass database when it is configured as the secret backend while not present in the bucket.
-- Also sort policy Principals to prevent unnecessary policy updates.
-- Re-use ServiceAccount object instead of MinioCredentials object which is effectively the same.
-- Allow cleaning up of removed resources, e.g. service account that doesn't have a related bucket.
-- Improve logging not to show stack trace when log level is not DEBUG.
-- Add colours to different log levels.
-- Create container image of project.
-- Add lifecycle management to created buckets.
-- Consider implementing object locking.
+Check the open [enhancement](https://github.com/Alveel/minio-manager/issues?q=is%3Aissue+is%3Aopen+label%3Aenhancement) issues.
 
 ---
 


### PR DESCRIPTION
Due to the following message:

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-python@v4, pdm-project/setup-pdm@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.