### PR TITLE
Always pass and return ServiceAccount objects; don't pass single keys.

### DIFF
--- a/minio_manager/classes/controller_user.py
+++ b/minio_manager/classes/controller_user.py
@@ -9,9 +9,10 @@ class ControllerUser(ServiceAccount):
     """
 
     def __init__(self, name: str):
-        basic_account = ServiceAccount(name=name)
-        account = secrets.get_credentials(basic_account, required=True)
-        super().__init__(account.full_name, access_key=account.access_key, secret_key=account.secret_key)
+        super().__init__(name=name)
+        account = secrets.get_credentials(self, required=True)
+        self.access_key = account.access_key
+        self.secret_key = account.secret_key
 
 
 controller_user = ControllerUser(name=settings.minio_controller_user)

--- a/minio_manager/classes/controller_user.py
+++ b/minio_manager/classes/controller_user.py
@@ -1,25 +1,17 @@
+from minio_manager.classes.minio_resources import ServiceAccount
 from minio_manager.classes.secrets import secrets
 from minio_manager.classes.settings import settings
 
 
-class ControllerUser:
+class ControllerUser(ServiceAccount):
     """
     ControllerUser represents the controller user of our application.
-
-    name: The name of the controller user
-    access_key: The access key of the controller user
-    secret_key: The secret key of the controller user
     """
 
-    name: str
-    access_key: str
-    secret_key: str
-
     def __init__(self, name: str):
-        self.name = name
-        credentials = secrets.get_credentials(name, required=True)
-        self.access_key = credentials.access_key
-        self.secret_key = credentials.secret_key
+        basic_account = ServiceAccount(name=name)
+        account = secrets.get_credentials(basic_account, required=True)
+        super().__init__(account.full_name, access_key=account.access_key, secret_key=account.secret_key)
 
 
 controller_user = ControllerUser(name=settings.minio_controller_user)

--- a/minio_manager/classes/minio_resources.py
+++ b/minio_manager/classes/minio_resources.py
@@ -80,13 +80,8 @@ class ServiceAccount:
         policy: dict | None = None,
         policy_file: Path | str | None = None,
     ):
-        if len(name) > 32:
-            self.name = name[:32]
-            self.description = name + " " + description
-        else:
-            self.name = name
-            self.description = description
-
+        self.name = name[:32]
+        self.description = name + " " + description
         self.full_name = name
         self.access_key = access_key
         self.secret_key = secret_key

--- a/minio_manager/classes/resource_parser.py
+++ b/minio_manager/classes/resource_parser.py
@@ -203,7 +203,7 @@ class ClusterResources:
         return bucket_policy_objects
 
     @staticmethod
-    def parse_service_accounts(service_accounts: list):
+    def parse_service_accounts(service_accounts: list) -> list[ServiceAccount]:
         """
         Parse a list of service account definitions into ServiceAccount objects.
 

--- a/minio_manager/clients.py
+++ b/minio_manager/clients.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+import json
+
 from minio import Minio, MinioAdmin, credentials
 
 from minio_manager.classes.controller_user import controller_user
-from minio_manager.classes.mc_wrapper import mc_wrapper
 from minio_manager.classes.settings import settings
 
 s3_client = Minio(
@@ -14,4 +15,6 @@ s3_client = Minio(
 )
 admin_provider = credentials.StaticProvider(controller_user.access_key, controller_user.secret_key)
 admin_client = MinioAdmin(endpoint=settings.s3_endpoint, credentials=admin_provider, secure=settings.s3_endpoint_secure)
-controller_user_policy = mc_wrapper.service_account_info(controller_user.access_key)["policy"]
+controller_user_info_raw = admin_client.get_service_account(controller_user.access_key)
+controller_user = json.loads(controller_user_info_raw)
+controller_user_policy = json.loads(controller_user["policy"])


### PR DESCRIPTION
Also:

- Refactor ControllerUser making it inherit ServiceAccount
- Simplify ServiceAccount __init__

This is a breaking change for Keepass databases if you have service accounts that are over 32 characters long.