### PR TITLE
Improve check if get_bucket_lifecycle() works

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -7,7 +7,7 @@ on:
     branches:
       - main
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened]
 
 jobs:
   quality:

--- a/minio_manager/bucket_handler.py
+++ b/minio_manager/bucket_handler.py
@@ -3,6 +3,7 @@ from minio import S3Error
 from minio_manager.classes.client_manager import client_manager
 from minio_manager.classes.logging_config import logger
 from minio_manager.classes.minio_resources import Bucket, ServiceAccount
+from minio_manager.classes.settings import settings
 from minio_manager.service_account_handler import handle_service_account
 from minio_manager.utilities import compare_objects, increment_error_count
 
@@ -25,29 +26,64 @@ def configure_versioning(bucket):
         logger.debug(f"Bucket {bucket.name}: versioning {bucket.versioning.status.lower()}")
 
 
-def configure_lifecycle(bucket):
-    if not bucket.lifecycle_config:
-        return
+def check_bucket_lifecycle(bucket):
+    """
+    Check the lifecycle management policy for the specified bucket.
+    This function compares the current lifecycle management policy with the desired state.
+    Return True if the lifecycle management policy is already up to date, False if not or if we encounter any errors.
 
+    :param bucket: Bucket object
+    :return: bool
+    """
     # First compare the current lifecycle configuration with the desired configuration
     logger.debug(f"Bucket {bucket.name}: comparing existing lifecycle management policy with desired state for bucket")
     try:
         lifecycle_status = client_manager.s3.get_bucket_lifecycle(bucket.name)
+        settings._get_on_lifecycle_supported = True
         lifecycle_diff = compare_objects(lifecycle_status, bucket.lifecycle_config)
         if not lifecycle_diff:
             # If there is no difference, there is no need to update the lifecycle configuration
             logger.debug(f"Bucket {bucket.name}: lifecycle management policies already up to date")
-            return
+            return True
 
         logger.debug(f"Bucket {bucket.name}: current lifecycle management policy does not match desired state")
     except ValueError as ve:
-        if ve.args == "Rule filter must be provided":
-            logger.debug("Endpoint does not appear to support a GET request on the lifecycle API.")
-        else:
-            logger.error(f"Error getting lifecycle configuration: {ve.args}, ")
-            return
+        # This error is expected if the bucket does not have a lifecycle configuration
+        if "Rule filter must be provided" not in ve.args:
+            logger.error(f"Unknown error getting lifecycle configuration: {ve.args}, ")
+        if not hasattr(settings, "_get_on_lifecycle_supported"):
+            logger.warning("minio-py does not appear to support a GET request on this lifecycle API endpoint!")
+            logger.warning("This is possibly caused by differences in MinIO and other S3-compatible solutions.")
+            logger.warning("Ignoring this error and always overwriting the lifecycle policy.")
+            settings._get_on_lifecycle_supported = False
+        return False
 
-    # First clean up the existing lifecycle configuration
+
+def configure_lifecycle(bucket):
+    """
+    Configure the lifecycle management policy for the specified bucket.
+
+    :param bucket: Bucket object
+    """
+    if not bucket.lifecycle_config:
+        return
+
+    # Check if get_bucket_lifecycle() works. If we found previously it is not, we skip this check,
+    # don't compare what's live on the server, and fallback to always overwriting any lifecycle configuration.
+    # noinspection PyProtectedMember
+    if not hasattr(settings, "_get_on_lifecycle_supported"):
+        # Check if the lifecycle configuration is supported
+        if check_bucket_lifecycle(bucket):
+            return
+    elif settings._get_on_lifecycle_supported:
+        # get_bucket_lifecycle() works, compare the current lifecycle configuration with the desired state
+        if check_bucket_lifecycle(bucket):
+            return
+    else:
+        logger.debug("get_bucket_lifecycle() does not appear to work, overwriting lifecycle policy")
+
+    # Updating existing lifecycle configuration was found to be problematic, so we always delete any existing
+    # lifecycle configuration before setting the new one.
     client_manager.s3.delete_bucket_lifecycle(bucket.name)
     logger.debug(f"Bucket {bucket.name}: removed existing lifecycle management policy")
     client_manager.s3.set_bucket_lifecycle(bucket.name, bucket.lifecycle_config)

--- a/minio_manager/bucket_handler.py
+++ b/minio_manager/bucket_handler.py
@@ -5,7 +5,7 @@ from minio_manager.classes.logging_config import logger
 from minio_manager.classes.minio_resources import Bucket, ServiceAccount
 from minio_manager.classes.settings import settings
 from minio_manager.service_account_handler import handle_service_account
-from minio_manager.utilities import compare_objects, increment_error_count
+from minio_manager.utilities import compare_objects
 
 
 def configure_versioning(bucket):
@@ -24,7 +24,6 @@ def configure_versioning(bucket):
         except S3Error as s3e:
             if s3e.code == "InvalidBucketState":
                 logger.error(f"Bucket {bucket.name}: error setting versioning: {s3e.message}")
-                increment_error_count()
                 return
         if bucket.versioning.status == "Suspended":
             logger.warning(f"Bucket {bucket.name}: versioning is suspended!")
@@ -112,11 +111,9 @@ def handle_bucket(bucket: Bucket):
         if s3e.code == "AccessDenied":
             logger.error(f"Controller user does not have permission to manage bucket {bucket.name}")
             logger.debug(s3e.message)
-            increment_error_count()
             return
         else:
             logger.error(f"Unknown error creating bucket {bucket.name}: {s3e.message}")
-            increment_error_count()
             return
 
     configure_versioning(bucket)

--- a/minio_manager/classes/logging_config.py
+++ b/minio_manager/classes/logging_config.py
@@ -3,6 +3,7 @@ import sys
 from logging import DEBUG, INFO, Filter, Formatter, Logger, LogRecord, StreamHandler
 
 from minio_manager.classes.settings import settings
+from minio_manager.utilities import increment_error_count
 
 RED = "\033[0;31m"
 GREEN = "\033[0;32m"
@@ -94,6 +95,10 @@ class MinioManagerLogger(Logger):
         handler.setFormatter(formatter)
         handler.addFilter(this_filter)
         self.addHandler(handler)
+
+    def error(self, msg, *args, **kwargs):
+        super().error(msg, *args, **kwargs)
+        increment_error_count()
 
     def critical(self, msg, *args, **kwargs):
         super().critical(msg, *args, **kwargs)

--- a/minio_manager/classes/minio_resources.py
+++ b/minio_manager/classes/minio_resources.py
@@ -10,7 +10,7 @@ from minio.versioningconfig import VersioningConfig
 
 from minio_manager.classes.logging_config import logger
 from minio_manager.classes.settings import settings
-from minio_manager.utilities import increment_error_count, read_json
+from minio_manager.utilities import read_json
 
 
 class Bucket:
@@ -31,9 +31,9 @@ class Bucket:
         lifecycle_config: LifecycleConfig | None = None,
     ):
         if len(name) > 63 or len(name) < 3:
-            logger.error(f"Bucket '{name}' is {len(name)} characters long;")
-            logger.error("Bucket names must be between 3 and 63 characters in length!")
-            increment_error_count()
+            logger.error(
+                f"Bucket '{name}' is {len(name)} characters long; Bucket names must be between 3 and 63 characters in length!"
+            )
 
         self.name = name
         self.create_service_account = create_service_account
@@ -98,7 +98,6 @@ class ServiceAccount:
                 self.policy = read_json(self.policy_file)
             except FileNotFoundError:
                 logger.error(f"Policy file '{self.policy_file}' for service account '{name}' not found!")
-                increment_error_count()
 
     def generate_service_account_policy(self):
         """

--- a/minio_manager/classes/settings.py
+++ b/minio_manager/classes/settings.py
@@ -89,6 +89,8 @@ class Settings(BaseSettings):
         default="", description="The service account policy file to use as a template"
     )
 
+    _get_on_lifecycle_supported: bool = True
+
     @classmethod
     def settings_customise_sources(
         cls,

--- a/minio_manager/policy_handler.py
+++ b/minio_manager/policy_handler.py
@@ -34,7 +34,9 @@ def handle_bucket_policy(bucket_policy: BucketPolicy):
                 current_policy = client_manager.s3.get_bucket_policy(bucket_policy.bucket)
             except S3Error as sbe:
                 if sbe.code == "MalformedPolicy":
-                    logger.exception("Do the resources in the policy file match the bucket name? Is it valid JSON?")
+                    logger.error(
+                        "Unable to apply policy: do the resources in the policy file match the bucket name? Is it valid JSON?"
+                    )
                     return
 
     policies_diff = compare_objects(current_policy, desired_policy)
@@ -44,8 +46,8 @@ def handle_bucket_policy(bucket_policy: BucketPolicy):
     logger.info(f"Desired bucket policy for '{bucket_policy.bucket}' does not match current policy. Updating.")
     try:
         client_manager.s3.set_bucket_policy(bucket_policy.bucket, desired_policy_json)
-    except S3Error:
-        logger.exception("Failed to update bucket policy")
+    except S3Error as s3e:
+        logger.error(f"Failed to update bucket policy: {s3e.code}")
 
 
 def handle_iam_policy(iam_policy: IamPolicy):

--- a/minio_manager/policy_handler.py
+++ b/minio_manager/policy_handler.py
@@ -35,7 +35,6 @@ def handle_bucket_policy(bucket_policy: BucketPolicy):
             except S3Error as sbe:
                 if sbe.code == "MalformedPolicy":
                     logger.exception("Do the resources in the policy file match the bucket name? Is it valid JSON?")
-                    increment_error_count()
                     return
 
     policies_diff = compare_objects(current_policy, desired_policy)
@@ -47,7 +46,6 @@ def handle_bucket_policy(bucket_policy: BucketPolicy):
         client_manager.s3.set_bucket_policy(bucket_policy.bucket, desired_policy_json)
     except S3Error:
         logger.exception("Failed to update bucket policy")
-        increment_error_count()
 
 
 def handle_iam_policy(iam_policy: IamPolicy):


### PR DESCRIPTION
There seems to be an issue with minio-py and `get_bucket_lifecycle()` when talking to Ceph RGW. This aims to circumvent this issue in a bit of a hacky way.

I believe this code might be erroneously throwing an error if a lifecycle configuration contains no rules:

https://github.com/minio/minio-py/blob/82c6c1af876983b6658ed0c91f3edc7d08d47c7b/minio/lifecycleconfig.py#L457

From what I understand, if no lifecycle config exists, it's just a lifecycle config without any rules.